### PR TITLE
Update ojph to 0.8.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.7.0" %}
+{% set version = "0.8.0" %}
 
 package:
   name: ojph
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/o/ojph/ojph-{{ version }}.tar.gz
-  sha256: 8de2d5522186822c642cb5016e7eeaa2637226a9712090ee7c7bda68f746f2ba
+  sha256: 7e8b4add1bc19baa4f40378b5f6fb72552ac2e98b33bd97ecdf8ff8b6851a59f
 
 build:
   script: python -m pip install . -vv


### PR DESCRIPTION
Bump `ojph` to `0.8.0` — minimal change: just `version` + `sha256`, using the standard PyPI sdist (which bakes its own version, so no build tweaks or git needed).

<sub>Earlier revisions test-built from a git branch / release archive to exercise the reworked binary-wheels build ([ramonaoptics/ojph#30](https://github.com/ramonaoptics/ojph/pull/30)) on conda-forge before a PyPI release existed — which confirmed all platforms build, and that a git source hangs the Windows agents. Now the clean release form.</sub>